### PR TITLE
Optionally inject JsonSerializerSettings 

### DIFF
--- a/MediatR.Behaviors.Logging.AspNetCore/LogExecutionBehavior.cs
+++ b/MediatR.Behaviors.Logging.AspNetCore/LogExecutionBehavior.cs
@@ -9,17 +9,19 @@ namespace MediatR.Behaviors.Logging.AspNetCore
     public class LogExecutionBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     {
         private readonly ILogger<TRequest> _logger;
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
 
-        public LogExecutionBehavior(ILogger<TRequest> logger)
+        public LogExecutionBehavior(ILogger<TRequest> logger, JsonSerializerSettings jsonSerializerSettings = null)
         {
             _logger = logger;
+            _jsonSerializerSettings = jsonSerializerSettings ?? new JsonSerializerSettings();
         }
 
         public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             var correlationId = Guid.NewGuid();
             var timer = new System.Diagnostics.Stopwatch();
-            var data = JsonConvert.SerializeObject(request);
+            var data = JsonConvert.SerializeObject(request, _jsonSerializerSettings);
             using (var loggingScope = _logger.BeginScope("{MeditatorRequestName} with {MeditatorRequestData}, correlation id {CorrelationId}", typeof(TRequest).Name, data, correlationId))
             {
                 try


### PR DESCRIPTION
Hi Raphael,
This PR is to allow for customisable serialization scenarios and would fix an issue for my project where the serialization fails because it requires custom converters.  

I made it an optional parameter so it will just create a default JsonSerializerSettings if nothing is passed in.

Thanks
Dan